### PR TITLE
タスクランナーとして `go-task`  を導入

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
     "Anson",
     "buildx",
     "CEINTL",
+    "choco",
     "cmds",
     "eamodio",
     "Gruntfuggly",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,9 @@
 {
   "cSpell.words": [
     "Anson",
+    "buildx",
     "CEINTL",
+    "cmds",
     "eamodio",
     "Gruntfuggly",
     "mhutchie",

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN sed -i 's@archive.ubuntu.com@ftp.jaist.ac.jp/pub/Linux@g' /etc/apt/sources.l
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && chsh -s /bin/zsh \
+  && go install github.com/go-task/task/v3/cmd/task@latest \
   && go install golang.org/x/tools/gopls@latest \
   && go install honnef.co/go/tools/cmd/staticcheck@latest \
   && go install golang.org/x/tools/cmd/goimports@latest \

--- a/README.md
+++ b/README.md
@@ -1,3 +1,106 @@
 # hello-golang
 
 Subjects for learning golang on the "A Tour of Go"
+
+## Get Started
+
+### タスクランナーのインストール
+
+テストの実行用に以下のタスクランナーを使用する想定です。
+
+- [Task](https://taskfile.dev/)
+
+利用しなくともテストの実行は可能ですが、すぐにインストールできるためよろしければ導入ください。
+
+#### Via Go Module
+
+Go をローカルにインストール済みの方は以下のコマンドで導入可能です。
+
+```bash
+go install github.com/go-task/task/v3/cmd/task@latest
+```
+
+#### For Mac
+
+```bash
+brew install go-task/tap/go-task
+```
+
+#### For Linux
+
+```bash
+sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
+```
+
+#### For Windows
+
+```bash
+choco install go-task
+```
+
+## Usage
+
+### ローカルから Docker コンテナ内の Shell を操作する
+
+タスクランナーに以下のコマンドを定義しています。
+
+```bash
+task docker-bash # bashで接続
+
+task docker-zsh  # zsh で接続
+```
+
+お好きな方の Shell を選んでタスクを実行すると、 Container が立ち上がって内部の Shell に接続された状態になります。
+
+`--rm` フラグをつけているのでコンテナは都度破棄されます。
+
+### テストの実行
+
+Golang は標準でテスト実行用のコマンドが用意されており、以下のコマンドで実行することができます。
+
+```bash
+# すべてのテストを実行する場合
+go test ./...
+
+# 特定のパッケージのテストを実行する場合
+go test ./<package-name>
+```
+
+また、タスクランナーにテスト実行用のタスクを定義済みです。
+
+以下から適したタスクを走らせてテストを実行してください。
+
+#### ローカルの Go バイナリを使用して or Container 内でテストを実行する場合
+
+```bash
+task test
+```
+
+特定のパッケージのみテストしたい場合は以下のように `--` の後にパッケージ名を渡して実行してください。
+
+```bash
+task test -- <package-name>
+```
+
+#### ローカルから Docker を利用してテストを実行する場合
+
+初めて利用する場合はまず DockerImage をビルドします。
+
+```bash
+task docker-build
+```
+
+DockerImage がビルド済みの状態で以下のコマンドを実行すると DockerContainer が立ち上がり、 Container 内でテストコマンドを実行することができます
+
+```bash
+task docker-test
+
+# ローカルと同じようにパッケージ指定も可能です
+task docker-test -- <package-name>
+```
+
+上記 2 つを同時に実行することもできます。
+
+```bash
+task docker-build-test
+```

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -11,30 +11,44 @@ tasks:
       - task: test
 
   test:
+    desc: Execute testing via local golang binary
     cmds:
       - go test -v ./{{.CLI_ARGS | default "..."}}
+    silent: true
 
   docker-build:
+    desc: Build Docker Image
     cmds:
       - docker buildx build --tag {{.IMAGE_NAME}} .
+    silent: true
 
   docker-bash:
+    desc: Connect via Bash into container
     cmds:
       - docker run -it --rm -v ${PWD}:/go/src/app {{.IMAGE_NAME}} bash
+    silent: true
 
   docker-zsh:
+    desc: Connect via Zsh into container
     cmds:
       - docker run -it --rm -v ${PWD}:/go/src/app {{.IMAGE_NAME}} zsh
+    silent: true
 
   docker-test:
+    desc: Execute testing via Docker
     cmds:
       - docker run --rm -v ${PWD}:/go/src/app {{.IMAGE_NAME}} go test -v ./{{.CLI_ARGS | default "..."}}
+    silent: true
 
   docker-build-test:
+    desc: Execute building Docker Image and testing on Container
     cmds:
       - task: docker-build
       - task: docker-test
+    silent: true
 
   docker-prune:
+    desc: Remove Docker resources
     cmds:
       - docker system prune -f
+    silent: true

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -4,7 +4,6 @@ version: "3"
 
 vars:
   IMAGE_NAME: hello-golang:latest
-  PACKAGE: '{{default "..." .PACKAGE}}'
 
 tasks:
   default:
@@ -13,15 +12,23 @@ tasks:
 
   test:
     cmds:
-      - go test -v ./{{.PACKAGE}}
+      - go test -v ./{{.CLI_ARGS | default "..."}}
 
   docker-build:
     cmds:
       - docker buildx build --tag {{.IMAGE_NAME}} .
 
+  docker-bash:
+    cmds:
+      - docker run -it --rm -v ${PWD}:/go/src/app {{.IMAGE_NAME}} bash
+
+  docker-zsh:
+    cmds:
+      - docker run -it --rm -v ${PWD}:/go/src/app {{.IMAGE_NAME}} zsh
+
   docker-test:
     cmds:
-      - docker run --rm -v ${PWD}:/go/src/app {{.IMAGE_NAME}} go test -v ./{{.PACKAGE}}
+      - docker run --rm -v ${PWD}:/go/src/app {{.IMAGE_NAME}} go test -v ./{{.CLI_ARGS | default "..."}}
 
   docker-build-test:
     cmds:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,0 +1,33 @@
+# https://taskfile.dev
+
+version: "3"
+
+vars:
+  IMAGE_NAME: hello-golang:latest
+  PACKAGE: '{{default "..." .PACKAGE}}'
+
+tasks:
+  default:
+    deps:
+      - task: test
+
+  test:
+    cmds:
+      - go test -v ./{{.PACKAGE}}
+
+  docker-build:
+    cmds:
+      - docker buildx build --tag {{.IMAGE_NAME}} .
+
+  docker-test:
+    cmds:
+      - docker run --rm -v ${PWD}:/go/src/app {{.IMAGE_NAME}} go test -v ./{{.PACKAGE}}
+
+  docker-build-test:
+    cmds:
+      - task: docker-build
+      - task: docker-test
+
+  docker-prune:
+    cmds:
+      - docker system prune -f


### PR DESCRIPTION
## やったこと

- [x] `go-task` を Dockerfile 内で追加
- [x] Docker 関連のタスク定義を `Taskfile.yml` に追加
- [x] テスト関連のタスク定義を `Taskfile.yml` に追加
- [x] 追加した内容を `README.md` に追記

## 確認方法

`go-task` を導入してコマンドを試していただけますと 🙏 

```bash
brew install go-task/tap/go-task
# or
go install github.com/go-task/task/v3/cmd/task@latest

# taskの実行
task test # => go test が実行されます
```

## References

- https://github.com/kurupeku/hello-golang/issues/12

Close #12 