### PR TITLE
fix: hepler method return type

### DIFF
--- a/subject/chapter03/README.md
+++ b/subject/chapter03/README.md
@@ -56,8 +56,8 @@
 
 `helper` パッケージ内に
 
-- `func InnerLoopDistance(current string) string` 内回り用
-- `func OuterLoopDistance(current string) string` 外回り用
+- `func InnerLoopDistance(current string) int` 内回り用
+- `func OuterLoopDistance(current string) int` 外回り用
 
 を用意しています。
 


### PR DESCRIPTION
Chapter03のREADMEの記述で一部ミスがあったため修正のPR出します。

- Helper関数の説明で関数定義の型が実際と違っている